### PR TITLE
improved error handling for unsupported devices

### DIFF
--- a/3D Tester/ViewController.swift
+++ b/3D Tester/ViewController.swift
@@ -23,7 +23,7 @@ class ViewController: UIViewController {
         case .Available: compatible = true
         default: adviseLabel.text = 
             compatible = false
-            "Unsupported device!"
+            adviceLabel.text = "Unsupported device!"
             percentLabel.text = "Error!"
         }
     }

--- a/3D Tester/ViewController.swift
+++ b/3D Tester/ViewController.swift
@@ -14,32 +14,39 @@ class ViewController: UIViewController {
     @IBOutlet weak var percentLabel: UILabel!
 
     var forceAmount: CGFloat = 0.0
+    var compatible: Bool
 
     override func viewDidLoad() {
         super.viewDidLoad()
         
         switch self.traitCollection.forceTouchCapability {
-        case .Available: return
-        default: adviseLabel.text = "Unsupported device!"
+        case .Available: compatible = true
+        default: adviseLabel.text = 
+            compatible = false
+            "Unsupported device!"
             percentLabel.text = "Error!"
         }
     }
     
     override func touchesBegan(touches: Set<UITouch>, withEvent event: UIEvent?) {
-        handleTouch(touches.first!)
+        if compatible { handleTouch(touches.first!) }
     }
     
     override func touchesMoved(touches: Set<UITouch>, withEvent event: UIEvent?) {
-        handleTouch(touches.first!)
+        if compatible { handleTouch(touches.first!) }
     }
     
     override func touchesEnded(touches: Set<UITouch>, withEvent event: UIEvent?) {
-        self.view.backgroundColor = UIColor(white: 1, alpha: 1)
+        if compatible {
         
-        adviseLabel.textColor = UIColor.blackColor()
-        percentLabel.textColor = UIColor.blackColor()
+            self.view.backgroundColor = UIColor(white: 1, alpha: 1)
         
-        percentLabel.text = "0%"
+            adviseLabel.textColor = UIColor.blackColor()
+            percentLabel.textColor = UIColor.blackColor()
+        
+            percentLabel.text = "0%"
+            
+         }
     }
     
     func handleTouch(touch:UITouch) {

--- a/3D Tester/ViewController.swift
+++ b/3D Tester/ViewController.swift
@@ -12,18 +12,18 @@ class ViewController: UIViewController {
     
     @IBOutlet weak var adviseLabel: UILabel!
     @IBOutlet weak var percentLabel: UILabel!
-
+    
     var forceAmount: CGFloat = 0.0
-    var compatible: Bool
-
+    var compatible = true
+    
     override func viewDidLoad() {
         super.viewDidLoad()
         
         switch self.traitCollection.forceTouchCapability {
         case .Available: compatible = true
-        default: adviseLabel.text = 
+        default:
             compatible = false
-            adviceLabel.text = "Unsupported device!"
+            adviseLabel.text = "Unsupported device!"
             percentLabel.text = "Error!"
         }
     }
@@ -38,19 +38,19 @@ class ViewController: UIViewController {
     
     override func touchesEnded(touches: Set<UITouch>, withEvent event: UIEvent?) {
         if compatible {
-        
+            
             self.view.backgroundColor = UIColor(white: 1, alpha: 1)
-        
+            
             adviseLabel.textColor = UIColor.blackColor()
             percentLabel.textColor = UIColor.blackColor()
-        
+            
             percentLabel.text = "0%"
             
-         }
+        }
     }
     
     func handleTouch(touch:UITouch) {
-
+        
         forceAmount = touch.force/touch.maximumPossibleForce
         let exactPercent = forceAmount*100
         let percent = String(format: "%.0f%%", exactPercent)
@@ -61,10 +61,10 @@ class ViewController: UIViewController {
         
         adviseLabel.textColor = UIColor(red: forceAmount, green: forceAmount, blue: forceAmount, alpha: 1)
         percentLabel.textColor = UIColor(red: forceAmount, green: forceAmount, blue: forceAmount, alpha: 1)
-
+        
         setNeedsStatusBarAppearanceUpdate()
     }
-
+    
     override func preferredStatusBarStyle() -> UIStatusBarStyle {
         return forceAmount > 0.5 ? .LightContent : .Default
     }


### PR DESCRIPTION
Still untested, should throw the error for unsupported devices and do nothing when the user touches the screen anyways
